### PR TITLE
Feature/buttonlabel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 bower_components
 node_modules

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,7 +22,7 @@
       <h3>ServiceWorker update toast</h3>
       <demo-snippet>
         <template>
-          <sw-update-toast demo></sw-update-toast>
+          <sw-update-toast opened message="Site update available!" button-label="Reload"></sw-update-toast>
         </template>
       </demo-snippet>
     </div>

--- a/sw-update-toast.html
+++ b/sw-update-toast.html
@@ -13,9 +13,9 @@
         text-decoration: none;
       }
     </style>
-    <paper-toast id="toast" duration="[[ duration ]]" opened="[[ demo ]]">
+    <paper-toast id="toast" duration="[[ duration ]]" opened="[[ opened ]]">
       <span>[[ message ]]</span>
-      <a href on-click="_reload">Reload</a>
+      <a href on-click="_reload">[[ buttonLabel ]]</a>
     </paper-toast>
   </template>
 
@@ -42,13 +42,19 @@
             type: String,
             value: "Site update available!",
           },
+
+          /** label for reload button */
+          buttonLabel: {
+            type: String,
+            value: "Reload",
+          },
           /** duration the toast should be shown, default 0 to persist. */
           duration: {
             type: Number,
             value: 0,
           },
-          /** demo mode, open the toast */
-          demo: {
+          /** open the toast */
+          opened: {
             type: Boolean,
             value: false,
           }

--- a/test/sw-update-toast_test.html
+++ b/test/sw-update-toast_test.html
@@ -31,9 +31,9 @@
       </template>
     </test-fixture>
 
-    <test-fixture id="DemoMode">
+    <test-fixture id="Opened">
       <template>
-        <sw-update-toast demo></sw-update-toast>
+        <sw-update-toast opened></sw-update-toast>
       </template>
     </test-fixture>
 
@@ -67,9 +67,9 @@
           assert.equal(elementToast.duration, 5);
         });
 
-        test('setting demo mode opens toast', function() {
-          var element = fixture('DemoMode');
-          assert.equal(element.demo, true);
+        test('setting opened mode opens toast', function() {
+          var element = fixture('Opened');
+          assert.equal(element.opened, true);
           var elementShadowRoot = element.shadowRoot;
           var elementToast = elementShadowRoot.querySelector('paper-toast');
           assert.equal(elementToast.opened, true);


### PR DESCRIPTION
- Button label added, because sometimes you want to call the Reload "Aktualisieren"
- Demo mode changed to opened, because you want to open the toast and using the attribute demo does not feel naturally .
- Test updated
